### PR TITLE
Add padding for programlisting element

### DIFF
--- a/style/fo-stylesheet.xsl
+++ b/style/fo-stylesheet.xsl
@@ -49,6 +49,7 @@
 			<xsl:text>pt</xsl:text>
 		</xsl:attribute>
 		<xsl:attribute name="background-color">#ebebeb</xsl:attribute>
+		<xsl:attribute name="padding">3pt</xsl:attribute>
 	</xsl:attribute-set>
 
 	<xsl:template match="processing-instruction('hard-pagebreak')">


### PR DESCRIPTION
This PR adds padding to the `programlisting` element by adding a `padding` attribute to the `monospace.verbatim.properties`.